### PR TITLE
Fix decimal conversion for USDC + fix oracle call

### DIFF
--- a/contracts/InternalMarket/InternalMarket.sol
+++ b/contracts/InternalMarket/InternalMarket.sol
@@ -2,7 +2,7 @@
 
 pragma solidity ^0.8.16;
 
-import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import "@openzeppelin/contracts/token/ERC20/ERC20.sol";
 import "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol";
 import "@openzeppelin/contracts-upgradeable/access/AccessControlUpgradeable.sol";
 import "../ShareholderRegistry/IShareholderRegistry.sol";
@@ -43,7 +43,7 @@ contract InternalMarket is
     }
 
     function setExchangePair(
-        IERC20 token,
+        ERC20 token,
         IStdReference oracle
     ) public onlyRole(Roles.RESOLUTION_ROLE) {
         _setExchangePair(token, oracle);

--- a/test/InternalMarket.ts
+++ b/test/InternalMarket.ts
@@ -3,10 +3,12 @@ import { SignerWithAddress } from "@nomiclabs/hardhat-ethers/signers";
 import chai from "chai";
 import chaiAsPromised from "chai-as-promised";
 import { solidity } from "ethereum-waffle";
+import { BigNumber } from "ethers";
 import { parseEther } from "ethers/lib/utils";
 import { ethers, network, upgrades } from "hardhat";
 
 import {
+  ERC20,
   IERC20,
   IRedemptionController,
   IStdReference,
@@ -33,7 +35,7 @@ describe("InternalMarket", async () => {
   let internalMarket: InternalMarket;
   let redemption: FakeContract<IRedemptionController>;
   let stdReference: FakeContract<IStdReference>;
-  let usdc: FakeContract<IERC20>;
+  let usdc: FakeContract<ERC20>;
   let deployer: SignerWithAddress;
   let alice: SignerWithAddress;
   let bob: SignerWithAddress;
@@ -45,7 +47,8 @@ describe("InternalMarket", async () => {
     [deployer, alice, bob, carol, reserve] = await ethers.getSigners();
 
     token = await smock.fake("IERC20");
-    usdc = await smock.fake("IERC20");
+    usdc = await smock.fake("ERC20");
+    usdc.decimals.returns(6);
 
     const InternalMarketFactory = (await ethers.getContractFactory(
       "InternalMarket",
@@ -91,6 +94,10 @@ describe("InternalMarket", async () => {
   afterEach(async () => {
     await network.provider.send("evm_revert", [snapshotId]);
   });
+
+  function parseUSDC(usdc: number) {
+    return usdc * 10 ** 6;
+  }
 
   describe("setExchangePair", async () => {
     it("should allow a resolution to set token and oracle addresses", async () => {
@@ -190,13 +197,13 @@ describe("InternalMarket", async () => {
 
         describe("when the exchange rate is 1/1", async () => {
           beforeEach(async () => {
-            stdReference.getReferenceData.whenCalledWith("eur", "usd").returns({
+            stdReference.getReferenceData.whenCalledWith("EUR", "USD").returns({
               rate: parseEther("1"),
               lastUpdatedBase: parseEther("0"),
               lastUpdatedQuote: parseEther("0"),
             });
             stdReference.getReferenceData
-              .whenCalledWith("usdc", "usd")
+              .whenCalledWith("USDC", "USD")
               .returns({
                 rate: parseEther("1"),
                 lastUpdatedBase: parseEther("0"),
@@ -214,36 +221,25 @@ describe("InternalMarket", async () => {
             expect(usdc.transferFrom).calledWith(
               reserve.address,
               alice.address,
-              parseEther("10")
+              parseUSDC(10)
             );
           });
         });
 
         describe("when the exchange rate is 1/2", async () => {
           beforeEach(async () => {
-            stdReference.getReferenceData.whenCalledWith("eur", "usd").returns({
+            stdReference.getReferenceData.whenCalledWith("EUR", "USD").returns({
               rate: parseEther("2"),
               lastUpdatedBase: parseEther("0"),
               lastUpdatedQuote: parseEther("0"),
             });
             stdReference.getReferenceData
-              .whenCalledWith("usdc", "usd")
+              .whenCalledWith("USDC", "USD")
               .returns({
                 rate: parseEther("1"),
                 lastUpdatedBase: parseEther("0"),
                 lastUpdatedQuote: parseEther("0"),
               });
-          });
-
-          it("should exchange the 10 DAO tokens sats for 20 USDC sats", async () => {
-            await internalMarket.connect(alice).redeem(10);
-
-            expect(token.transfer).calledWith(reserve.address, 10);
-            expect(usdc.transferFrom).calledWith(
-              reserve.address,
-              alice.address,
-              20
-            );
           });
 
           it("should exchange the 10 DAO token for 20 USDC", async () => {
@@ -256,20 +252,20 @@ describe("InternalMarket", async () => {
             expect(usdc.transferFrom).calledWith(
               reserve.address,
               alice.address,
-              parseEther("20")
+              parseUSDC(20)
             );
           });
         });
 
         describe("when the exchange rate is 1.12 eur/usd and 0.998 usdc/usd", async () => {
           beforeEach(async () => {
-            stdReference.getReferenceData.whenCalledWith("eur", "usd").returns({
+            stdReference.getReferenceData.whenCalledWith("EUR", "USD").returns({
               rate: parseEther("1.12"),
               lastUpdatedBase: parseEther("0"),
               lastUpdatedQuote: parseEther("0"),
             });
             stdReference.getReferenceData
-              .whenCalledWith("usdc", "usd")
+              .whenCalledWith("USDC", "USD")
               .returns({
                 rate: parseEther("0.998"),
                 lastUpdatedBase: parseEther("0"),
@@ -277,7 +273,7 @@ describe("InternalMarket", async () => {
               });
           });
 
-          it("should exchange the 10 DAO tokens for 11.22244488977956 USDC", async () => {
+          it("should exchange the 10 DAO tokens for 11.222444 USDC", async () => {
             await internalMarket.connect(alice).redeem(parseEther("10"));
 
             expect(token.transfer).calledWith(
@@ -287,47 +283,25 @@ describe("InternalMarket", async () => {
             expect(usdc.transferFrom).calledWith(
               reserve.address,
               alice.address,
-              parseEther("11.222444889779559118")
+              parseUSDC(11.222444)
             );
           });
         });
 
         describe("when the exchange rate is 2/1", async () => {
           beforeEach(async () => {
-            stdReference.getReferenceData.whenCalledWith("eur", "usd").returns({
+            stdReference.getReferenceData.whenCalledWith("EUR", "USD").returns({
               rate: parseEther("1"),
               lastUpdatedBase: parseEther("0"),
               lastUpdatedQuote: parseEther("0"),
             });
             stdReference.getReferenceData
-              .whenCalledWith("usdc", "usd")
+              .whenCalledWith("USDC", "USD")
               .returns({
                 rate: parseEther("2"),
                 lastUpdatedBase: parseEther("0"),
                 lastUpdatedQuote: parseEther("0"),
               });
-          });
-
-          it("should exchange the 10 DAO token sats for 5 USDC sats", async () => {
-            await internalMarket.connect(alice).redeem(10);
-
-            expect(token.transfer).calledWith(reserve.address, 10);
-            expect(usdc.transferFrom).calledWith(
-              reserve.address,
-              alice.address,
-              5
-            );
-          });
-
-          it("should exchange the 11 DAO token sats for 5 USDC sats", async () => {
-            await internalMarket.connect(alice).redeem(11);
-
-            expect(token.transfer).calledWith(reserve.address, 11);
-            expect(usdc.transferFrom).calledWith(
-              reserve.address,
-              alice.address,
-              5
-            );
           });
 
           it("should exchange the 11 DAO tokens for 5.5 USDC", async () => {
@@ -340,7 +314,7 @@ describe("InternalMarket", async () => {
             expect(usdc.transferFrom).calledWith(
               reserve.address,
               alice.address,
-              parseEther("5.5")
+              parseUSDC(5.5)
             );
           });
 
@@ -359,14 +333,14 @@ describe("InternalMarket", async () => {
 
       describe("with 50 unlocked tokens and 100 locked tokens", async () => {
         beforeEach(async () => {
-          await internalMarket.connect(alice).makeOffer(50);
+          await internalMarket.connect(alice).makeOffer(parseEther("50"));
           let ts = await getEVMTimestamp();
 
           // Unlock 50 tokens
           await setEVMTimestamp(ts + DAY * 7);
 
           // Lock 100 tokens
-          await internalMarket.connect(alice).makeOffer(100);
+          await internalMarket.connect(alice).makeOffer(parseEther("100"));
         });
 
         describe("and no tokens in the user wallet", async () => {
@@ -376,31 +350,34 @@ describe("InternalMarket", async () => {
 
           it("should fail when the user redeems 70 tokens", async () => {
             // smock2 bug causes this error rather than the faked one
-            await expect(internalMarket.connect(alice).redeem(70)).revertedWith(
-              "function returned an unexpected amount of data"
-            );
+            await expect(
+              internalMarket.connect(alice).redeem(parseEther("70"))
+            ).revertedWith("function returned an unexpected amount of data");
           });
 
           it("should fail when the user redeems 60 tokens", async () => {
-            await expect(internalMarket.connect(alice).redeem(60)).revertedWith(
-              "function returned an unexpected amount of data"
-            );
+            await expect(
+              internalMarket.connect(alice).redeem(parseEther("60"))
+            ).revertedWith("function returned an unexpected amount of data");
           });
 
           describe("when user redeems 50 tokens", async () => {
             beforeEach(async () => {
-              await internalMarket.connect(alice).redeem(50);
+              await internalMarket.connect(alice).redeem(parseEther("50"));
             });
 
             it("should transfer 50 tokens from market to reserve", async () => {
-              expect(token.transfer).calledWith(reserve.address, 50);
+              expect(token.transfer).calledWith(
+                reserve.address,
+                parseEther("50")
+              );
             });
 
             it("should transfer 50 usdc from reserve to alice", async () => {
               expect(usdc.transferFrom).calledWith(
                 reserve.address,
                 alice.address,
-                50
+                parseUSDC(50)
               );
             });
           });
@@ -409,64 +386,70 @@ describe("InternalMarket", async () => {
         describe("and 10 tokens in the user wallet", async () => {
           beforeEach(async () => {
             token.transferFrom
-              .whenCalledWith(alice.address, reserve.address, 20)
+              .whenCalledWith(alice.address, reserve.address, parseEther("20"))
               .reverts("ERC20: insufficient balance");
           });
 
           it("should fail when the user redeems 70 tokens", async () => {
-            await expect(internalMarket.connect(alice).redeem(70)).revertedWith(
-              "function returned an unexpected amount of data"
-            );
+            await expect(
+              internalMarket.connect(alice).redeem(parseEther("70"))
+            ).revertedWith("function returned an unexpected amount of data");
           });
 
           describe("when the user redeems 60 tokens", async () => {
             beforeEach(async () => {
-              await internalMarket.connect(alice).redeem(60);
+              await internalMarket.connect(alice).redeem(parseEther("60"));
             });
 
             it("should transfer 10 tokens from alice to internal market and then to reserve", async () => {
               expect(token.transferFrom).calledWith(
                 alice.address,
                 reserve.address,
-                10
+                parseEther("10")
               );
             });
 
             it("should transfer 50 tokens from market to reserve", async () => {
-              expect(token.transfer).calledWith(reserve.address, 50);
+              expect(token.transfer).calledWith(
+                reserve.address,
+                parseEther("50")
+              );
             });
 
             it("should transfer 60 usdc from reserve to alice", async () => {
               expect(usdc.transferFrom).calledWith(
                 reserve.address,
                 alice.address,
-                60
+                parseUSDC(60)
               );
             });
           });
 
           describe("when the user redeems 50 tokens", async () => {
             beforeEach(async () => {
-              await internalMarket.connect(alice).redeem(50);
+              await internalMarket.connect(alice).redeem(parseEther("50"));
             });
 
             it("should not transfer 10 tokens from alice to reserve", async () => {
               expect(token.transferFrom).not.calledWith(
                 alice.address,
                 reserve.address,
-                10
+                parseEther("10")
               );
             });
 
             it("should transfer 50 tokens from market to reserve", async () => {
-              expect(token.transfer).calledWith(reserve.address, 50);
+              expect(token.transfer).calledWith(
+                reserve.address,
+                parseEther("50")
+              );
             });
 
             it("should transfer 50 usdc from reserve to alice", async () => {
               expect(usdc.transferFrom).calledWith(
                 reserve.address,
                 alice.address,
-                50
+                parseUSDC(50)
               );
             });
           });
@@ -539,12 +522,12 @@ describe("InternalMarket", async () => {
 
       describe("when the exchange rate is 1/1", async () => {
         beforeEach(async () => {
-          stdReference.getReferenceData.whenCalledWith("eur", "usd").returns({
+          stdReference.getReferenceData.whenCalledWith("EUR", "USD").returns({
             rate: parseEther("1"),
             lastUpdatedBase: parseEther("0"),
             lastUpdatedQuote: parseEther("0"),
           });
-          stdReference.getReferenceData.whenCalledWith("usdc", "usd").returns({
+          stdReference.getReferenceData.whenCalledWith("USDC", "USD").returns({
             rate: parseEther("1"),
             lastUpdatedBase: parseEther("0"),
             lastUpdatedQuote: parseEther("0"),
@@ -552,30 +535,32 @@ describe("InternalMarket", async () => {
         });
 
         it("should exchange the 10 DAO tokens for 10 USDC", async () => {
-          await internalMarket.connect(bob).matchOffer(alice.address, 10);
-          expect(token.transfer).calledWith(bob.address, 10);
-          expect(usdc.transferFrom).calledWith(bob.address, alice.address, 10);
+          await internalMarket.connect(alice).makeOffer(parseEther("10"));
+
+          await internalMarket
+            .connect(bob)
+            .matchOffer(alice.address, parseEther("10"));
+          expect(token.transfer).calledWith(bob.address, parseEther("10"));
+          expect(usdc.transferFrom).calledWith(
+            bob.address,
+            alice.address,
+            parseUSDC(10)
+          );
         });
       });
 
       describe("when the exchange rate is 1/2", async () => {
         beforeEach(async () => {
-          stdReference.getReferenceData.whenCalledWith("eur", "usd").returns({
+          stdReference.getReferenceData.whenCalledWith("EUR", "USD").returns({
             rate: parseEther("2"),
             lastUpdatedBase: parseEther("0"),
             lastUpdatedQuote: parseEther("0"),
           });
-          stdReference.getReferenceData.whenCalledWith("usdc", "usd").returns({
+          stdReference.getReferenceData.whenCalledWith("USDC", "USD").returns({
             rate: parseEther("1"),
             lastUpdatedBase: parseEther("0"),
             lastUpdatedQuote: parseEther("0"),
           });
-        });
-
-        it("should exchange the 10 DAO tokens sats for 20 USDC sats", async () => {
-          await internalMarket.connect(bob).matchOffer(alice.address, 10);
-          expect(token.transfer).calledWith(bob.address, 10);
-          expect(usdc.transferFrom).calledWith(bob.address, alice.address, 20);
         });
 
         it("should exchange the 10 DAO token for 20 USDC", async () => {
@@ -588,26 +573,26 @@ describe("InternalMarket", async () => {
           expect(usdc.transferFrom).calledWith(
             bob.address,
             alice.address,
-            parseEther("20")
+            parseUSDC(20)
           );
         });
       });
 
       describe("when the exchange rate is 1.12 eur/usd and 0.998 usdc/usd", async () => {
         beforeEach(async () => {
-          stdReference.getReferenceData.whenCalledWith("eur", "usd").returns({
+          stdReference.getReferenceData.whenCalledWith("EUR", "USD").returns({
             rate: parseEther("1.12"),
             lastUpdatedBase: parseEther("0"),
             lastUpdatedQuote: parseEther("0"),
           });
-          stdReference.getReferenceData.whenCalledWith("usdc", "usd").returns({
+          stdReference.getReferenceData.whenCalledWith("USDC", "USD").returns({
             rate: parseEther("0.998"),
             lastUpdatedBase: parseEther("0"),
             lastUpdatedQuote: parseEther("0"),
           });
         });
 
-        it("should exchange the 10 DAO tokens for 11.22244488977956 USDC", async () => {
+        it("should exchange the 10 DAO tokens for 11.222444 USDC", async () => {
           await internalMarket.connect(alice).makeOffer(parseEther("10"));
 
           await internalMarket
@@ -617,35 +602,23 @@ describe("InternalMarket", async () => {
           expect(usdc.transferFrom).calledWith(
             bob.address,
             alice.address,
-            parseEther("11.222444889779559118")
+            parseUSDC(11.222444)
           );
         });
       });
 
       describe("when the exchange rate is 2/1", async () => {
         beforeEach(async () => {
-          stdReference.getReferenceData.whenCalledWith("eur", "usd").returns({
+          stdReference.getReferenceData.whenCalledWith("EUR", "USD").returns({
             rate: parseEther("1"),
             lastUpdatedBase: parseEther("0"),
             lastUpdatedQuote: parseEther("0"),
           });
-          stdReference.getReferenceData.whenCalledWith("usdc", "usd").returns({
+          stdReference.getReferenceData.whenCalledWith("USDC", "USD").returns({
             rate: parseEther("2"),
             lastUpdatedBase: parseEther("0"),
             lastUpdatedQuote: parseEther("0"),
           });
-        });
-
-        it("should exchange the 10 DAO token sats for 5 USDC sats", async () => {
-          await internalMarket.connect(bob).matchOffer(alice.address, 10);
-          expect(token.transfer).calledWith(bob.address, 10);
-          expect(usdc.transferFrom).calledWith(bob.address, alice.address, 5);
-        });
-
-        it("should exchange the 11 DAO token sats for 5 USDC sats", async () => {
-          await internalMarket.connect(bob).matchOffer(alice.address, 11);
-          expect(token.transfer).calledWith(bob.address, 11);
-          expect(usdc.transferFrom).calledWith(bob.address, alice.address, 5);
         });
 
         it("should exchange the 11 DAO tokens for 5.5 USDC", async () => {
@@ -658,7 +631,7 @@ describe("InternalMarket", async () => {
           expect(usdc.transferFrom).calledWith(
             bob.address,
             alice.address,
-            parseEther("5.5")
+            parseUSDC(5.5)
           );
         });
 

--- a/test/utils/deploy.ts
+++ b/test/utils/deploy.ts
@@ -102,8 +102,8 @@ export async function deployDAO(
   oracle = await PriceOracleFactory.deploy();
   await oracle.deployed();
 
-  await oracle.relay(["eur", "usd"], [1, 1], [1, 1]);
-  await oracle.relay(["usdc", "usd"], [1, 1], [1, 1]);
+  await oracle.relay(["EUR", "USD"], [1, 1], [1, 1]);
+  await oracle.relay(["USDC", "USD"], [1, 1], [1, 1]);
 
   redemption = (await upgrades.deployProxy(RedemptionControllerFactory, {
     initializer: "initialize",


### PR DESCRIPTION
* USDC has 6 decimals, unlike most of the ERC20 tokens. Hence the conversion function had to be amended
* The Price Oracle uses uppercase reference keys (e.g.: "USDC" and no "usdc"), hence the call and tests had to be fixed 