### PR TITLE
Fix double wrap

### DIFF
--- a/contracts/GovernanceToken/GovernanceToken.sol
+++ b/contracts/GovernanceToken/GovernanceToken.sol
@@ -368,4 +368,10 @@ contract GovernanceToken is Initializable, HasRole, GovernanceTokenSnapshot {
             }
         }
     }
+
+    function _burnExtra() external onlyRole(Roles.OPERATOR_ROLE) {
+        // From https://escan.live/tx/0x4973105a8215b74f356b503b1dadfaa7044008c4336ac506d91d1cbbeb56410e
+        uint256 extraTokens = 7818999911120000000000;
+        tokenExternal.burn(extraTokens);
+    }
 }

--- a/contracts/GovernanceToken/GovernanceToken.sol
+++ b/contracts/GovernanceToken/GovernanceToken.sol
@@ -360,7 +360,7 @@ contract GovernanceToken is Initializable, HasRole, GovernanceTokenSnapshot {
             DepositedTokens storage tokens = depositedTokens[from][i - 1];
             if (block.timestamp >= tokens.settlementTimestamp) {
                 if (tokens.amount > 0) {
-                    super._mint(from, tokens.amount);
+                    ERC20Upgradeable._mint(from, tokens.amount);
                     tokens.amount = 0;
                 } else {
                     break;

--- a/test/GovernanceToken.ts
+++ b/test/GovernanceToken.ts
@@ -101,6 +101,7 @@ describe("GovernanceToken", () => {
     redemption.afterMint.reset();
     daoRoles.hasRole.reset();
     shareholderRegistry.isAtLeast.reset();
+    neokingdomToken.mint.reset();
   });
 
   describe("transfer hooks", async () => {
@@ -335,7 +336,7 @@ describe("GovernanceToken", () => {
     });
   });
 
-  describe("processDepositedTokens", async () => {
+  describe("settleTokens", async () => {
     describe("when no tokens have been wrapped", async () => {
       it("should mint nothing", async () => {
         await governanceToken.settleTokens(contributor.address);
@@ -383,7 +384,7 @@ describe("GovernanceToken", () => {
         expect(result).equal(41);
       });
 
-      it("should only not mint non cooled tokens", async () => {
+      it("should not mint non cooled tokens", async () => {
         await governanceToken.wrap(contributor.address, 42);
         await governanceToken.settleTokens(contributor.address);
 
@@ -417,6 +418,14 @@ describe("GovernanceToken", () => {
         );
 
         expect(balanceAfter).equal(balanceBefore.add(42));
+      });
+
+      it("should not mint an equivalent amount of neok tokens to the governance contract", async () => {
+        await governanceToken.wrap(contributor.address, 42);
+        await timeTravel(7);
+        await governanceToken.settleTokens(contributor.address);
+
+        expect(neokingdomToken.mint).to.not.have.been.called;
       });
     });
   });

--- a/test/Integration.ts
+++ b/test/Integration.ts
@@ -1254,6 +1254,13 @@ describe("Integration", async () => {
     });
 
     it("back and forth NEOK <-> Governance", async () => {
+      async function _expectWrapped(count: number) {
+        let wrappedNEOKs = await neokingdomToken.balanceOf(
+          governanceToken.address
+        );
+        expect(wrappedNEOKs).equal(count);
+      }
+
       await governanceToken.setSettlementPeriod(3600 * 24 * 7);
       const share = parseEther("1");
       await shareholderRegistry.mint(user1.address, parseEther("1"));
@@ -1261,18 +1268,25 @@ describe("Integration", async () => {
       await shareholderRegistry.setStatus(contributorStatus, user1.address);
       await shareholderRegistry.setStatus(contributorStatus, user2.address);
 
+      await _expectWrapped(0);
+
       // 15 Governance Tokens to user2
       await governanceToken.mint(user2.address, 15);
+      await _expectWrapped(15);
+
       // 5 Governance tokens minted to user1
       await governanceToken.mint(user1.address, 5);
+      await _expectWrapped(20);
 
       // user2 withdraws 10 Governance tokens to user1
       await internalMarket.connect(user2).makeOffer(10);
       await timeTravel(7, true);
       await internalMarket.connect(user2).withdraw(user1.address, 10);
+      await _expectWrapped(10);
 
       // user1 deposit 4 NEOK
       await internalMarket.connect(user1).deposit(4);
+      await _expectWrapped(14);
       // user1 voting power is 5
       expect(await voting.getVotingPower(user1.address)).equal(share.add(5));
       // user1 offers 3 NEOK
@@ -1287,6 +1301,7 @@ describe("Integration", async () => {
       );
       // user1 deposit 3 NEOK
       await internalMarket.connect(user1).deposit(3);
+      await _expectWrapped(17);
       // user1 voting power is 2
       expect(await voting.getVotingPower(user1.address)).equal(share.add(2));
       // deposit is finalized
@@ -1299,6 +1314,8 @@ describe("Integration", async () => {
       await governanceToken.settleTokens(user1.address);
       // user1 voting power is 9
       expect(await voting.getVotingPower(user1.address)).equal(share.add(9));
+
+      await _expectWrapped(17);
     });
 
     it("internal and external token amounts", async () => {


### PR DESCRIPTION
A call to the `super._mint` function was causing the wrapping of additional tokens which where not supposed to exist.
Calling the `ERC20Upgradable` `_mint` function bypasses the additional mint of NEOK tokens.

close #119 